### PR TITLE
fix: compatibilize test and build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "devDependencies": {
     "@types/node": "^20.11.17",
     "@vitest/coverage-v8": "^1.2.2",
-    "dotenv": "^16.4.2",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard-with-typescript": "^43.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ devDependencies:
   '@vitest/coverage-v8':
     specifier: ^1.2.2
     version: 1.2.2(vitest@1.2.2)
-  dotenv:
-    specifier: ^16.4.2
-    version: 16.4.2
   eslint:
     specifier: ^8.56.0
     version: 8.56.0
@@ -1120,11 +1117,6 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
-    dev: true
-
-  /dotenv@16.4.2:
-    resolution: {integrity: sha512-rZSSFxke7d9nYQ5NeMIwp5PP+f8wXgKNljpOb7KtH6SKW1cEqcXAz9VSJYVLKe7Jhup/gUYOkaeSVyK8GJ+nBg==}
-    engines: {node: '>=12'}
     dev: true
 
   /effect@2.3.3:

--- a/src/account/balancemulti/call.ts
+++ b/src/account/balancemulti/call.ts
@@ -8,6 +8,7 @@ import type {
   BalanceMultiParams,
   BalanceMultiRequest,
   BalanceMultiActionCall,
+  BalanceMultiResultObject,
 } from "./types";
 import { AccountModuleName } from "etherscan/account";
 import {
@@ -61,31 +62,32 @@ if (import.meta.vitest !== undefined) {
       address: FixtureValidity.Invalid,
     });
 
-    let defaultResultObject: BalanceMultiResult;
+    let baseResultList: BalanceMultiResultObject[];
     const addressRegExp = /0x[a-fA-F0-9]{40}/;
 
     beforeAll(async () => {
-      defaultResultObject = await balanceMulti(
+      const { result } = await balanceMulti(
         EtherscanBaseUrl.Sepolia,
         balanceMultiParams,
       );
-      defaultResultObject.result ??= [{ account: "", balance: -1n }];
+      baseResultList = result ?? [];
     });
 
     it("should return an object result", async () => {
-      expect(defaultResultObject.result).toBeTypeOf("object");
+      expect(baseResultList).toBeTypeOf("object");
     });
 
     it("should return an object with a balance greater or equal than zero", async () => {
-      const balanceValid = defaultResultObject.result.every((result) => {
+      const balanceValid = baseResultList.every((result) => {
         return result.balance >= 0;
       });
+      expect(baseResultList).not.toContain([0]);
 
       expect(balanceValid).toStrictEqual(true);
     });
 
     it("should return an array containing only valid Ethereum addresses", async () => {
-      const addressesValid = defaultResultObject.result.every((result) => {
+      const addressesValid = baseResultList.every((result) => {
         return addressRegExp.test(result.account);
       });
 

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -45,9 +45,10 @@ export const createParamFixtureFactory = <T extends EtherscanParam>(
         break;
     }
 
-    const params: EtherscanParams<T> = { [paramName]: param };
-    return params;
+    const params = { [paramName]: param };
+    return params as EtherscanParams<T>;
   };
+
   return paramFixtureFactory;
 };
 
@@ -59,7 +60,7 @@ export const createParamFixtureFactory = <T extends EtherscanParam>(
 export const apiKeyFixtureFactory = createParamFixtureFactory<ApiKeyParam>(
   "apiKey",
   {
-    valid: () => process.env.ETHERSCAN_API_KEY ?? "",
+    valid: () => import.meta.env.VITE_ETHERSCAN_API_KEY ?? "",
     invalid: () => "invalid",
     default: () => "",
   },
@@ -73,7 +74,7 @@ export const apiKeyFixtureFactory = createParamFixtureFactory<ApiKeyParam>(
 export const addressFixtureFactory = createParamFixtureFactory<AddressParam>(
   "address",
   {
-    valid: () => process.env.SEPOLIA_ADDRESS ?? "",
+    valid: () => import.meta.env.VITE_SEPOLIA_ADDRESS ?? "",
     invalid: () => "invalid",
     default: () => "",
   },
@@ -86,7 +87,7 @@ export const addressFixtureFactory = createParamFixtureFactory<AddressParam>(
  */
 export const addressArrayFixtureFactory =
   createParamFixtureFactory<AddressArrayParam>("address", {
-    valid: () => (process.env.SEPOLIA_ADDRESS_ARRAY ?? "").split(","),
+    valid: () => (import.meta.env.VITE_SEPOLIA_ADDRESS_ARRAY ?? "").split(","),
     invalid: () => ["invalid"],
     default: () => [],
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Types */
-    "types": ["vitest/importMeta"],
+    "types": ["vite/client", "vitest/importMeta"],
     "exactOptionalPropertyTypes": true,
 
     /* Paths */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,26 @@
-/// <reference types="vitest" />
 import { resolve } from "path";
 import { defineConfig } from "vite";
 import eslint from "vite-plugin-eslint";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({
-  plugins: [eslint(), tsconfigPaths()],
-  build: {
-    lib: {
-      entry: resolve(__dirname, "src/index.ts"),
-      name: "etherscan",
-      fileName: "etherscan",
+export default defineConfig(({ mode }) => {
+  const config = {
+    plugins: [eslint(), tsconfigPaths()],
+    build: {
+      lib: {
+        entry: resolve(__dirname, "src/index.ts"),
+        name: "etherscan",
+        fileName: "etherscan",
+      },
     },
-  },
-  test: {
-    includeSource: ["src/**/*.ts"],
-    include: ["test/**/*.{test,spec}.ts?(x)"],
-    setupFiles: ["dotenv/config"],
-  },
+    test: {
+      includeSource: ["src/**/*.ts"],
+      include: ["test/**/*.{test,spec}.ts?(x)"],
+    },
+    define: {
+      "import.meta.vitest": mode === "development" ? "undefined" : undefined,
+    },
+  };
+
+  return config;
 });


### PR DESCRIPTION
## Description

This PR aims to make `test` and `build` scripts compatible.

Changes:
* Removed `dotenv` package in favor of native .env support in Vite (which means that now we access env variables with `import.meta.*`).
* Fixed multiple unnoticed TypeScript compiler errors.
* Disable Vitest in-source blocks in [production mode](https://vitejs.dev/guide/env-and-mode#modes).